### PR TITLE
Fix folder path disambiguation and server version resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,24 @@ add_project {
 }
 ```
 
+#### Folder Path Disambiguation
+
+When folders share the same name at different levels (e.g., both `Personal > Areas` and `Work > Areas`), use the full path with ` > ` separators to disambiguate:
+
+```bash
+# Disambiguate folders with the same name
+get_folder_by_id { "folderName": "Work > Areas" }
+get_folder_by_id { "folderName": "Personal > Areas" }
+
+# Filter projects by disambiguated folder
+list_projects { "folderName": "Work > Areas" }
+
+# Plain names still work (first match, backwards compatible)
+get_folder_by_id { "folderName": "Areas" }
+```
+
+Path syntax is supported everywhere a `folderName` parameter is accepted: `add_project`, `add_folder`, `edit_item`, `duplicate_project`, `batch_add_items`, `batch_edit_items`, `list_projects`, and `get_folder_by_id`.
+
 ### 3. 🔍 Perspective Views
 
 Access all major OmniFocus perspectives:

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,6 +1,22 @@
-# OmniFocus MCP Server - What's New (v1.30.7)
+# OmniFocus MCP Server - What's New (v1.31.0)
 
 > Summary of changes from Sprints 1-10 for AI assistants using this MCP server.
+
+## v1.31.0 Folder path disambiguation and server version fix (Issues #1, #2, #3)
+
+**Folder path disambiguation:**
+- All tools accepting `folderName` now support `"Parent > Child"` path syntax to disambiguate folders with the same name at different hierarchy levels (e.g., `"Work > Areas"` vs `"Personal > Areas"`)
+- Plain folder names still work (first match, backwards compatible)
+- Affected tools: `get_folder_by_id`, `add_project`, `add_folder`, `edit_item`, `duplicate_project`, `batch_add_items`, `batch_edit_items`, `list_projects`
+
+**Full folder paths in output:**
+- `list_projects` now returns full folder paths (e.g., `"Work > Areas"`) instead of bare names (`"Areas"`)
+- `get_folder_by_id` now includes a `path` field in its response
+
+**Server version fix:**
+- `get_server_version` no longer fails with ENOENT when the MCP server runs from a directory without a `package.json`
+
+---
 
 ## v1.30.7 Surface silent catch block errors in filter operations (Issues #104, #109)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "of-mcp",
   "type": "module",
-  "version": "1.30.7",
+  "version": "1.31.0",
   "description": "MCP server for OmniFocus with batch operations, custom perspectives, hierarchical tasks, and comprehensive task management",
   "main": "dist/server.js",
   "bin": {

--- a/src/tools/definitions/getServerVersion.ts
+++ b/src/tools/definitions/getServerVersion.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { ServerRequest, ServerNotification } from '@modelcontextprotocol/sdk/types.js';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -9,10 +9,20 @@ export const schema = z.object({});
 
 export async function handler(_args: z.infer<typeof schema>, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) {
   try {
-    // Get the package.json path relative to this file
+    // Resolve package.json relative to this file.
+    // Supports both esbuild bundle (dist/server.js → ../package.json)
+    // and tsc output (dist/tools/definitions/*.js → ../../../package.json)
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
-    const packageJsonPath = join(__dirname, '..', '..', '..', 'package.json');
+    const candidates = [
+      join(__dirname, '..', 'package.json'),
+      join(__dirname, '..', '..', 'package.json'),
+      join(__dirname, '..', '..', '..', 'package.json'),
+    ];
+    const packageJsonPath = candidates.find(p => existsSync(p));
+    if (!packageJsonPath) {
+      throw new Error(`package.json not found (searched from ${__dirname})`);
+    }
 
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 

--- a/src/utils/omnifocusScripts/addFolder.js
+++ b/src/utils/omnifocusScripts/addFolder.js
@@ -35,12 +35,7 @@
           });
         }
       } else if (parentFolderName) {
-        for (const folder of allFolders) {
-          if (folder.name === parentFolderName) {
-            parentFolder = folder;
-            break;
-          }
-        }
+        parentFolder = resolveFolderByName(parentFolderName, allFolders);
         if (!parentFolder) {
           return JSON.stringify({
             success: false,

--- a/src/utils/omnifocusScripts/addProject.js
+++ b/src/utils/omnifocusScripts/addProject.js
@@ -51,14 +51,9 @@
         }
       }
 
-      // Fall back to name lookup if ID not found or not provided
+      // Fall back to name lookup (supports "Parent > Child" paths)
       if (!container && folderName) {
-        for (const folder of allFolders) {
-          if (folder.name === folderName) {
-            container = folder;
-            break;
-          }
-        }
+        container = resolveFolderByName(folderName, allFolders);
       }
 
       if (!container) {

--- a/src/utils/omnifocusScripts/batchAddItems.js
+++ b/src/utils/omnifocusScripts/batchAddItems.js
@@ -66,10 +66,9 @@
       return tagsByName;
     }
 
-    function getFoldersByName() {
+    function getAllFolders() {
       if (!foldersByName) {
-        foldersByName = new Map();
-        flattenedFolders.forEach(f => foldersByName.set(f.name.toLowerCase(), f));
+        foldersByName = flattenedFolders;
       }
       return foldersByName;
     }
@@ -275,7 +274,7 @@
               container = getFoldersById().get(folderId);
             }
             if (!container && folderName) {
-              container = getFoldersByName().get(folderName.toLowerCase());
+              container = resolveFolderByName(folderName, getAllFolders());
             }
             if (!container) {
               const searchRef = folderId ? `ID "${folderId}"` : `name "${folderName}"`;

--- a/src/utils/omnifocusScripts/batchAddItems.js
+++ b/src/utils/omnifocusScripts/batchAddItems.js
@@ -19,7 +19,7 @@
     let tasksByName = null;
     let tasksById = null;
     let tagsByName = null;
-    let foldersByName = null;
+    let cachedFolders = null;
     let foldersById = null;
 
     function getProjectsByName() {
@@ -67,10 +67,10 @@
     }
 
     function getAllFolders() {
-      if (!foldersByName) {
-        foldersByName = flattenedFolders;
+      if (!cachedFolders) {
+        cachedFolders = flattenedFolders;
       }
-      return foldersByName;
+      return cachedFolders;
     }
 
     function getFoldersById() {

--- a/src/utils/omnifocusScripts/batchEditItems.js
+++ b/src/utils/omnifocusScripts/batchEditItems.js
@@ -88,10 +88,9 @@
       return tagsByName;
     }
 
-    function getFoldersByName() {
+    function getAllFolders() {
       if (!foldersByName) {
-        foldersByName = new Map();
-        flattenedFolders.forEach(f => foldersByName.set(f.name.toLowerCase(), f));
+        foldersByName = flattenedFolders;
       }
       return foldersByName;
     }
@@ -354,9 +353,9 @@
             targetFolder = getFoldersById().get(edit.newFolderId);
           }
 
-          // Fall back to name if ID not found or not provided
+          // Fall back to name (supports "Parent > Child" paths)
           if (!targetFolder && edit.newFolderName) {
-            targetFolder = getFoldersByName().get(edit.newFolderName.toLowerCase());
+            targetFolder = resolveFolderByName(edit.newFolderName, getAllFolders());
           }
 
           if (targetFolder) {

--- a/src/utils/omnifocusScripts/batchEditItems.js
+++ b/src/utils/omnifocusScripts/batchEditItems.js
@@ -41,7 +41,7 @@
     let tasksByName = null;
     let tasksById = null;
     let tagsByName = null;
-    let foldersByName = null;
+    let cachedFolders = null;
     let foldersById = null;
 
     function getProjectsByName() {
@@ -89,10 +89,10 @@
     }
 
     function getAllFolders() {
-      if (!foldersByName) {
-        foldersByName = flattenedFolders;
+      if (!cachedFolders) {
+        cachedFolders = flattenedFolders;
       }
-      return foldersByName;
+      return cachedFolders;
     }
 
     function getFoldersById() {

--- a/src/utils/omnifocusScripts/duplicateProject.js
+++ b/src/utils/omnifocusScripts/duplicateProject.js
@@ -43,8 +43,7 @@
       }
     }
     if (!targetFolder && folderName) {
-      const nameLower = folderName.toLowerCase();
-      targetFolder = flattenedFolders.find(f => f.name.toLowerCase() === nameLower);
+      targetFolder = resolveFolderByName(folderName, flattenedFolders);
       if (!targetFolder) {
         return JSON.stringify({
           success: false,

--- a/src/utils/omnifocusScripts/editItem.js
+++ b/src/utils/omnifocusScripts/editItem.js
@@ -61,8 +61,7 @@
     const tagsByName = new Map();
     flattenedTags.forEach(t => tagsByName.set(t.name.toLowerCase(), t));
 
-    const foldersByName = new Map();
-    flattenedFolders.forEach(f => foldersByName.set(f.name.toLowerCase(), f));
+    const allFolders = flattenedFolders;
 
     // Find the item using Maps
     let foundItem = null;
@@ -314,15 +313,17 @@
 
       // Try ID first
       if (args.newFolderId) {
-        // Build folder ID map if not already done
-        const foldersById = new Map();
-        flattenedFolders.forEach(f => foldersById.set(f.id.primaryKey, f));
-        targetFolder = foldersById.get(args.newFolderId);
+        for (const f of allFolders) {
+          if (f.id.primaryKey === args.newFolderId) {
+            targetFolder = f;
+            break;
+          }
+        }
       }
 
-      // Fall back to name if ID not found or not provided
+      // Fall back to name (supports "Parent > Child" paths)
       if (!targetFolder && args.newFolderName) {
-        targetFolder = foldersByName.get(args.newFolderName.toLowerCase());
+        targetFolder = resolveFolderByName(args.newFolderName, allFolders);
       }
 
       if (targetFolder) {

--- a/src/utils/omnifocusScripts/getFolderByName.js
+++ b/src/utils/omnifocusScripts/getFolderByName.js
@@ -26,15 +26,9 @@
       }
     }
 
-    // If not found by ID, search by name (case-insensitive)
+    // If not found by ID, search by name (supports "Parent > Child" paths)
     if (!foundFolder && folderName) {
-      const folderNameLower = folderName.toLowerCase();
-      for (const folder of allFolders) {
-        if (folder.name.toLowerCase() === folderNameLower) {
-          foundFolder = folder;
-          break;
-        }
-      }
+      foundFolder = resolveFolderByName(folderName, allFolders);
     }
 
     if (!foundFolder) {
@@ -83,7 +77,7 @@
       // Subfolder count not accessible
     }
 
-    // Get parent folder info
+    // Get parent folder info and full path
     try {
       if (foundFolder.parent && foundFolder.parent.folder) {
         folderInfo.parentFolderId = foundFolder.parent.id.primaryKey;
@@ -91,6 +85,12 @@
       }
     } catch (e) {
       // Parent folder not accessible
+    }
+
+    try {
+      folderInfo.path = getFolderPath(foundFolder);
+    } catch (e) {
+      folderInfo.path = foundFolder.name;
     }
 
     return JSON.stringify({

--- a/src/utils/omnifocusScripts/lib/sharedUtils.js
+++ b/src/utils/omnifocusScripts/lib/sharedUtils.js
@@ -73,6 +73,8 @@ function formatDate(date) {
  * @returns {string} - Full path with " > " separators
  */
 function getFolderPath(folder) {
+  // In OmniJS, folder.parent is falsy for root-level folders (verified via
+  // osascript testing), so the loop naturally stops without hitting Database.
   const parts = [];
   let current = folder;
   while (current) {

--- a/src/utils/omnifocusScripts/lib/sharedUtils.js
+++ b/src/utils/omnifocusScripts/lib/sharedUtils.js
@@ -67,6 +67,61 @@ function formatDate(date) {
 }
 
 /**
+ * Build the full ancestor path for a folder (e.g. "Work > Projects > Active").
+ * Walks up the parent chain. Returns the folder's own name if it has no parent.
+ * @param {Folder} folder - An OmniFocus Folder object
+ * @returns {string} - Full path with " > " separators
+ */
+function getFolderPath(folder) {
+  const parts = [];
+  let current = folder;
+  while (current) {
+    parts.unshift(current.name);
+    current = current.parent || null;
+  }
+  return parts.join(' > ');
+}
+
+/**
+ * Resolve a folder by name, supporting path-style disambiguation.
+ * Accepts plain names ("Projects") or paths ("Work > Projects").
+ * Plain names match any folder (first match). Paths match the full ancestor chain.
+ * Case-insensitive comparison.
+ * @param {string} folderName - Folder name or " > "-separated path
+ * @param {Array} allFolders - flattenedFolders array
+ * @returns {Folder|null} - Matched folder or null
+ */
+function resolveFolderByName(folderName, allFolders) {
+  const nameLower = folderName.toLowerCase();
+  const isPath = nameLower.indexOf(' > ') !== -1;
+
+  if (isPath) {
+    const pathLower = nameLower.split(' > ').map(function(s) { return s.trim(); });
+    const leafName = pathLower[pathLower.length - 1];
+    for (const folder of allFolders) {
+      if (folder.name.toLowerCase() !== leafName) continue;
+      // Walk up the parent chain and compare each segment
+      const actualPath = getFolderPath(folder).toLowerCase().split(' > ');
+      if (actualPath.length !== pathLower.length) continue;
+      let match = true;
+      for (let i = 0; i < pathLower.length; i++) {
+        if (actualPath[i] !== pathLower[i]) { match = false; break; }
+      }
+      if (match) return folder;
+    }
+    return null;
+  }
+
+  // Plain name: first case-insensitive match (existing behavior)
+  for (const folder of allFolders) {
+    if (folder.name.toLowerCase() === nameLower) {
+      return folder;
+    }
+  }
+  return null;
+}
+
+/**
  * Map of OmniFocus Task.Status enum values to human-readable strings.
  * Used for serializing task status in JSON responses.
  */

--- a/src/utils/omnifocusScripts/listProjects.js
+++ b/src/utils/omnifocusScripts/listProjects.js
@@ -55,8 +55,12 @@
       if (folderId && projectFolder.id.primaryKey === folderId) {
         return true;
       }
-      if (folderName && projectFolder.name.toLowerCase() === folderName.toLowerCase()) {
-        return true;
+      if (folderName) {
+        // Support path-style matching: compare against full path
+        const resolved = resolveFolderByName(folderName, flattenedFolders);
+        if (resolved && resolved.id.primaryKey === projectFolder.id.primaryKey) {
+          return true;
+        }
       }
       return false;
     }
@@ -111,13 +115,13 @@
         }
       } catch (e) {}
 
-      // Get folder info
+      // Get folder info (full path via getFolderPath from sharedUtils)
       let projectFolderId = null;
       let projectFolderName = null;
       try {
         if (project.parentFolder) {
           projectFolderId = project.parentFolder.id.primaryKey;
-          projectFolderName = project.parentFolder.name;
+          projectFolderName = getFolderPath(project.parentFolder);
         }
       } catch (e) {}
 

--- a/src/utils/omnifocusScripts/listProjects.js
+++ b/src/utils/omnifocusScripts/listProjects.js
@@ -41,9 +41,15 @@
       return statusMap[project.status] || "Unknown";
     }
 
+    // Resolve folder filter once (not per-project)
+    const resolvedFilterFolder = folderName
+      ? resolveFolderByName(folderName, flattenedFolders)
+      : null;
+    const filterFolderId = folderId || (resolvedFilterFolder ? resolvedFilterFolder.id.primaryKey : null);
+
     // Helper to check if project matches folder filter
     function matchesFolder(project) {
-      if (!folderName && !folderId) {
+      if (!filterFolderId) {
         return true; // No folder filter
       }
 
@@ -52,17 +58,7 @@
         return false; // Project has no folder, but filter requires one
       }
 
-      if (folderId && projectFolder.id.primaryKey === folderId) {
-        return true;
-      }
-      if (folderName) {
-        // Support path-style matching: compare against full path
-        const resolved = resolveFolderByName(folderName, flattenedFolders);
-        if (resolved && resolved.id.primaryKey === projectFolder.id.primaryKey) {
-          return true;
-        }
-      }
-      return false;
+      return projectFolder.id.primaryKey === filterFolderId;
     }
 
     // Helper to check if project matches status filter


### PR DESCRIPTION
## Summary
- **#2**: `get_server_version` now searches multiple candidate paths for `package.json`, supporting both esbuild bundle and tsc output layouts
- **#1 & #3**: Added `getFolderPath()` and `resolveFolderByName()` shared helpers. All folder-by-name lookups now support `"Parent > Child"` path syntax for disambiguation. `list_projects` and `get_folder_by_id` return full folder paths in output.

Closes #1, closes #2, closes #3

## Changed files
- `src/utils/omnifocusScripts/lib/sharedUtils.js` — new `getFolderPath()` and `resolveFolderByName()` helpers
- `src/tools/definitions/getServerVersion.ts` — candidate path search
- `src/utils/omnifocusScripts/getFolderByName.js` — use `resolveFolderByName`, add `path` to response
- `src/utils/omnifocusScripts/listProjects.js` — full folder paths in output, path-aware filtering
- `src/utils/omnifocusScripts/addProject.js` — use `resolveFolderByName`
- `src/utils/omnifocusScripts/addFolder.js` — use `resolveFolderByName`
- `src/utils/omnifocusScripts/editItem.js` — use `resolveFolderByName`
- `src/utils/omnifocusScripts/batchAddItems.js` — use `resolveFolderByName`
- `src/utils/omnifocusScripts/batchEditItems.js` — use `resolveFolderByName`
- `src/utils/omnifocusScripts/duplicateProject.js` — use `resolveFolderByName`

## Test plan
- [x] `get_server_version` returns 1.31.0 (no ENOENT error)
- [x] `list_projects` shows full paths (`"Work > Areas"` not `"Areas"`)
- [x] `get_folder_by_id` with `"Work > Areas"` and `"Personal > Areas"` returns different folders
- [x] `get_folder_by_id` with plain `"Areas"` still works (backwards compat)
- [x] `list_projects` filtered by `"Work > Areas"` returns only Work projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)